### PR TITLE
Python 3 compatibility

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -38,7 +38,7 @@ The interface mimics the familiar `json` module::
     }
 
     # To obtain a byte string, use dumps()
-    value = jsonx.dump(obj)
+    value = jsonx.dumps(obj)
 
     # To write directly to a file-like object, use dump()
     with open("output.xml") as fp:

--- a/jsonx.py
+++ b/jsonx.py
@@ -2,6 +2,7 @@
 JSONx module
 """
 
+from builtins import str
 import io
 from xml.sax.saxutils import XMLGenerator
 
@@ -32,8 +33,8 @@ def _write_item(xg, value, name=None, root=False):
 
     if isinstance(value, dict):
         xg.startElement('json:object', _make_attrs(name, root))
-        for k, v in value.iteritems():
-            if not isinstance(k, (str, unicode)):
+        for k, v in value.items():
+            if not isinstance(k, str):
                 raise ValueError("json keys must be strings")
             _write_item(xg, v, name=k)
 
@@ -55,7 +56,7 @@ def _write_item(xg, value, name=None, root=False):
         xg.endElement('json:null')
         return
 
-    if isinstance(value, unicode):
+    if isinstance(value, str):
         xg.startElement('json:string', _make_attrs(name))
         xg.characters(value)
         xg.endElement('json:string')
@@ -67,9 +68,9 @@ def _write_item(xg, value, name=None, root=False):
         xg.endElement('json:boolean')
         return
 
-    if isinstance(value, (int, long, float)):
+    if isinstance(value, (int, float)):
         xg.startElement('json:number', _make_attrs(name))
-        xg.characters(unicode(value))
+        xg.characters(str(value))
         xg.endElement('json:number')
         return
 

--- a/jsonx.py
+++ b/jsonx.py
@@ -2,7 +2,6 @@
 JSONx module
 """
 
-from builtins import str
 import io
 from xml.sax.saxutils import XMLGenerator
 


### PR DESCRIPTION
So, uhm... yeah. If you're interested I've done some changes in order for your fantastic(!) implementation of jsonx to run on python3.

Note that this is a breaking change due to iteritems() and items() between the two versions and the usage of builtins, so it's completely fine if you'd keep your version for python2!